### PR TITLE
結果にダブルクォートをつける

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM perl:5.39.3-bullseye
 RUN cpan -T \
     HTTP::Request \
     LWP::Protocol::https \
-    LWP::UserAgent \
-    YAML::Tiny
+    LWP::UserAgent
 
 WORKDIR /opt/app/
 COPY ./app/ /opt/app/

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ COPY --from=tld_list_maker /opt/app/tld_list.yaml ./tld_list.yaml
 ```yaml
 ---
 TLD:
-  - AAA
-  - AARP
-  - ABB
-  - ABBOTT
-  - ABBVIE
+  - "AAA"
+  - "AARP"
+  - "ABB"
+  - "ABBOTT"
+  - "ABBVIE"
   ~~~
-  - ZONE
-  - ZUERICH
-  - ZW
+  - "ZONE"
+  - "ZUERICH"
+  - "ZW"
 ```

--- a/app/ianaTLD2yaml.pl
+++ b/app/ianaTLD2yaml.pl
@@ -28,12 +28,15 @@ sub dump_yaml_list {
     my (@tld_list) = @_;
     my $filename = "tld_list.yaml";
 
-    my $data = {
-        TLD => \@tld_list,
-    };
+    open my $fh, '>', $filename or die "Cannot open file: $!";
+    print $fh "---\n";
+    print $fh "TLD:\n";
+    foreach my $tld (@tld_list) {
+        print $fh "  - \"$tld\"\n";
+    }
+    close $fh;
 
-    my $yaml = YAML::Tiny->new($data);
-    $yaml->write($filename);
+    print "YAML data has been written to $filename\n";
 }
 
 sub main {

--- a/app/ianaTLD2yaml.pl
+++ b/app/ianaTLD2yaml.pl
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 use LWP::UserAgent;
-use YAML::Tiny;
 require HTTP::Request;
 
 main();


### PR DESCRIPTION
`NO` ドメインが、yamlでFalse扱いされるケースがあるためダブルクォートで囲う。
それに伴い、`YAML::Tiny`を使用するとうまく行かないため、除外。